### PR TITLE
fix(realtime): 멀티노드 환경에서 부분 스트림 발생 방지(유니크 groupId 적용)

### DIFF
--- a/backend/waf-dashboard-api/src/main/resources/application.yml
+++ b/backend/waf-dashboard-api/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     consumer:
-      group-id: dashboard-realtime-group
+      group-id: dashboard-realtime-${HOSTNAME:local}-${SERVER_PORT:0}
       auto-offset-reset: latest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer


### PR DESCRIPTION
- LB 뒤 다중 인스턴스에서도 동일 이벤트 전송 보장

## Diff
```yml
      // 기존 
      group-id: dashboard-realtime-group

      // 수정
      group-id: dashboard-realtime-${HOSTNAME:local}-${SERVER_PORT:0}
```